### PR TITLE
Swift Package Manager integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Rideau",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "Rideau",
+            targets: ["Rideau"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/immortal79/TransitionPatch.git", from: "1.0.3")
+    ],
+    targets: [
+        .target(
+            name: "Rideau",
+            dependencies: ["TransitionPatch"],
+            path: "Rideau"),
+    ]
+)

--- a/Rideau/InternalUtils.swift
+++ b/Rideau/InternalUtils.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 func _getActualContentInset(from scrollView: UIScrollView) -> UIEdgeInsets {
@@ -36,3 +37,4 @@ func debugLog(_ items: Any...) {
   print(items)
   #endif
 }
+#endif

--- a/Rideau/RideauContainerBodyType.swift
+++ b/Rideau/RideauContainerBodyType.swift
@@ -21,6 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
+import UIKit
 /// An protocol that just provides utility methods.
 public protocol RideauContainerBodyType {
   
@@ -69,3 +71,4 @@ extension RideauContainerBodyType where Self : UIViewController {
     
   }
 }
+#endif

--- a/Rideau/RideauContainerView.swift
+++ b/Rideau/RideauContainerView.swift
@@ -21,7 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import Foundation
+import UIKit
 
 /// Main view
 /// This view will be translated with user interaction.
@@ -192,3 +194,4 @@ public final class RideauContainerView : UIView {
     
   }
 }
+#endif

--- a/Rideau/RideauInternalView.swift
+++ b/Rideau/RideauInternalView.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 import TransitionPatch
@@ -888,3 +889,4 @@ extension RideauInternalView : UIGestureRecognizerDelegate {
     
   }
 }
+#endif

--- a/Rideau/RideauMaskedCornerRoundedView.swift
+++ b/Rideau/RideauMaskedCornerRoundedView.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 open class RideauMaskedCornerRoundedView : UIView {
@@ -73,3 +74,4 @@ open class RideauMaskedCornerRoundedView : UIView {
   }
   
 }
+#endif

--- a/Rideau/RideauMaskedCornerRoundedViewController.swift
+++ b/Rideau/RideauMaskedCornerRoundedViewController.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 open class RideauMaskedCornerRoundedViewController : UIViewController {
@@ -135,4 +136,4 @@ open class RideauMaskedCornerRoundedViewController : UIViewController {
     setBodyViewController(viewController)
   }
 }
-
+#endif

--- a/Rideau/RideauSnapPoint.swift
+++ b/Rideau/RideauSnapPoint.swift
@@ -21,7 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import Foundation
+import UIKit
 
 public enum RideauSnapPoint : Hashable {
   
@@ -87,3 +89,4 @@ public struct ResolvedSnapPointRange : Hashable {
   }
   
 }
+#endif

--- a/Rideau/RideauThumbView.swift
+++ b/Rideau/RideauThumbView.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 open class RideauThumbView : UIView {
@@ -50,3 +51,4 @@ open class RideauThumbView : UIView {
     shapeLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: .infinity).cgPath
   }
 }
+#endif

--- a/Rideau/RideauTouchThroughView.swift
+++ b/Rideau/RideauTouchThroughView.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 public class RideauTouchThroughView : UIView {
@@ -36,3 +37,4 @@ public class RideauTouchThroughView : UIView {
     return view
   }
 }
+#endif

--- a/Rideau/RideauTransitionController.swift
+++ b/Rideau/RideauTransitionController.swift
@@ -21,7 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import Foundation
+import UIKit
 
 public final class RideauPresentTransitionController : NSObject, UIViewControllerAnimatedTransitioning {
   
@@ -93,4 +95,4 @@ public final class RideauDismissTransitionController : NSObject, UIViewControlle
     }
   }
 }
-
+#endif

--- a/Rideau/RideauView.swift
+++ b/Rideau/RideauView.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 /// The RideauViewDelegate protocol defines methods that allow you to know events and manage animations.
@@ -290,3 +291,4 @@ extension RideauView : RideauInternalViewDelegate {
   }
   
 }
+#endif

--- a/Rideau/RideauViewController.swift
+++ b/Rideau/RideauViewController.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 /// An Object that displays an RideauView with Presentation.
@@ -158,3 +159,4 @@ extension RideauViewController : UIViewControllerTransitioningDelegate {
   }
   
 }
+#endif

--- a/Rideau/RideauViewDragGestureRecognizer.swift
+++ b/Rideau/RideauViewDragGestureRecognizer.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit.UIGestureRecognizerSubclass
 
@@ -109,3 +110,4 @@ fileprivate struct ResponderChainIterator : IteratorProtocol, Sequence {
     return next
   }
 }
+#endif

--- a/Rideau/ScrollController.swift
+++ b/Rideau/ScrollController.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 final class ScrollController {
@@ -78,3 +79,4 @@ final class ScrollController {
   }
   
 }
+#endif


### PR DESCRIPTION
Hi !

This PR enables us to import this wonderful framework directly within Xcode's built-in swift package manager.
I don't know if it's the right way to do it as it's the first time I do this. I Had to wrap every single class with #if canImport(UIKit) as SPM doesn't support compiling only for one platform as written here : [https://developer.apple.com/documentation/xcode/creating_a_standalone_swift_package_with_xcode](url)

I also did a PR for the dependency 'TransitionPatch' but you will need to manually change the URL to your repo in the Package.swift


Signed-off-by: Philippe Weidmann <philweidmann@me.com>