### PR TITLE
fix wrong info plist assignment for framework

### DIFF
--- a/Rideau.xcodeproj/project.pbxproj
+++ b/Rideau.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -636,7 +636,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/RideauDemo/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Rideau/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -666,7 +666,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/RideauDemo/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Rideau/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Apple rejects my app right after uploading it with the following e-mail:

We identified one or more issues with a recent delivery for your app, "TheApp" 1.0 (1). Please correct the following issues, then upload again.

ITMS-90511: CFBundleIdentifier Collision - The Info.plist CFBundleIdentifier value 'me.muukii.Cabinet' of 'TheApp.app/Frameworks/Rideau.framework' is already in use by another application.

I did some research and found that the framework target may use the wrong info.plist file (the one from the demo).