### PR TITLE
Update GitHub Actions workflow to fix deprecated runners/actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: "26.4"
       - name: xcodebuild
         run: xcodebuild -scheme Rideau -sdk iphoneos CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
-    
+    runs-on: macos-15
+
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1.1
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.3"
-      - uses: actions/checkout@v2
+          xcode-version: latest-stable
       - name: xcodebuild
-        run: xcodebuild -scheme Rideau -sdk iphoneos
+        run: xcodebuild -scheme Rideau -sdk iphoneos CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
- Switch from macos-13 (retired) to macos-15
- Bump actions/checkout v2 -> v4 and reorder before setup-xcode
- Pin Xcode to latest-stable instead of legacy 14.3
- Disable code signing for iphoneos build on CI

https://claude.ai/code/session_013eWodbkmJebjY7Vuc63DA5