### PR TITLE
[codex] Remove backdrop dismissal pan gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ let sheet = RideauViewController(
   },
   initialSnapPoint: .fraction(0.5),
   resizingOption: .resizeToVisibleArea,
-  backdropColor: UIColor(white: 0, alpha: 0.5),
-  usesDismissalPanGestureOnBackdropView: true
+  backdropColor: UIColor(white: 0, alpha: 0.5)
 )
 
 present(sheet, animated: true)

--- a/Rideau/Core/RideauHostingView.swift
+++ b/Rideau/Core/RideauHostingView.swift
@@ -253,34 +253,6 @@ final class RideauHostingView: RideauTouchThroughView {
     layoutIfNeeded()
   }
 
-  /**
-   Registers other panGesture to enable dragging outside view.
-   */
-  func register(other panGesture: UIPanGestureRecognizer) {
-    panGesture.addTarget(self, action: #selector(handleExternalPan(_:)))
-  }
-
-  @objc private dynamic func handleExternalPan(_ gesture: UIPanGestureRecognizer) {
-    let translation = gesture.translation(in: gesture.view)
-    let velocity = gesture.velocity(in: gesture.view)
-    let location = gesture.location(in: gesture.view)
-    let value = ScrollViewInteroperableDragGestureValue(
-      translation: CGSize(width: translation.x, height: translation.y),
-      location: location,
-      velocity: CGSize(width: velocity.x, height: velocity.y)
-    )
-    switch gesture.state {
-    case .began, .changed:
-      handleDragChange(value: value)
-    case .ended, .cancelled, .failed:
-      handleDragEnd(value: value)
-    case .possible:
-      break
-    @unknown default:
-      break
-    }
-  }
-
   private func resolve(configuration: RideauView.Configuration) -> ResolvedState {
 
     let maxHeight = self.bounds.height - actualTopMargin

--- a/Rideau/Core/RideauView.swift
+++ b/Rideau/Core/RideauView.swift
@@ -241,10 +241,6 @@ public final class RideauView: RideauTouchThroughView {
     hostingView.update(configuration: configuration)
   }
 
-  public func register(other panGesture: UIPanGestureRecognizer) {
-    hostingView.register(other: panGesture)
-  }
-
   @available(*, unavailable, message: "Don't add view directory, add to RideauView.containerView")
   public override func addSubview(_ view: UIView) {
     assertionFailure("Don't add view directory, add to RideauView.containerView")

--- a/Rideau/Core/RideauViewController.swift
+++ b/Rideau/Core/RideauViewController.swift
@@ -45,8 +45,7 @@ open class RideauViewController: UIViewController {
     configuration: RideauView.Configuration,
     initialSnapPoint: RideauSnapPoint,
     resizingOption: RideauContentContainerView.ResizingOption,
-    backdropColor: UIColor = UIColor(white: 0, alpha: 0.2),
-    usesDismissalPanGestureOnBackdropView: Bool = true
+    backdropColor: UIColor = UIColor(white: 0, alpha: 0.2)
   ) {
 
     precondition(configuration.snapPoints.contains(initialSnapPoint))
@@ -64,20 +63,6 @@ open class RideauViewController: UIViewController {
 
     self.modalPresentationStyle = .overFullScreen
     self.transitioningDelegate = self
-
-    do {
-
-      if usesDismissalPanGestureOnBackdropView {
-
-        let pan = UIPanGestureRecognizer()
-
-        backgroundView.addGestureRecognizer(pan)
-
-        rideauView.register(other: pan)
-
-      }
-
-    }
 
     do {
       let tap = UITapGestureRecognizer(target: self, action: #selector(didTapBackdropView))

--- a/Rideau/spec.md
+++ b/Rideau/spec.md
@@ -109,14 +109,6 @@ ownership is decided by the submodule using `.onlyAtGestureStart`.
 - Rideau should not apply its own additional gate. Once `onChange` fires,
   Rideau can assume the user has already moved at least 15 pt.
 
-### 3.5 External Gestures via `register(other:)`
-
-- Input coming from an external `UIPanGestureRecognizer` does not go through the
-  submodule. It is forwarded directly into `handleDragChange` and
-  `handleDragEnd`.
-- The inner scroll view is not involved on this path, so the scroll-lock flag
-  is irrelevant. This path behaves like Section 3.1.
-
 ## 4. Snap Resolution on Gesture End
 
 - Final position `nextPosition`:

--- a/RideauDemo/DemoPresentViewController.swift
+++ b/RideauDemo/DemoPresentViewController.swift
@@ -49,8 +49,7 @@ final class DemoPresentViewController: UIViewController {
       },
       initialSnapPoint: initialSnapPoint,
       resizingOption: resizingOption,
-      backdropColor: UIColor(white: 0, alpha: 0.5),
-      usesDismissalPanGestureOnBackdropView: true
+      backdropColor: UIColor(white: 0, alpha: 0.5)
     )
     present(controller, animated: true)
   }


### PR DESCRIPTION
## Summary

- Remove the backdrop pan-dismiss option from `RideauViewController`.
- Remove the now-unused external pan registration API and handler path from `RideauView` / `RideauHostingView`.
- Update the demo, README, and gesture spec to match the remaining tap-to-dismiss backdrop behavior.

## Why

The backdrop pan-dismiss behavior is being dropped because it does not match Apple's sheet behavior. With that feature gone, the external gesture registration path no longer has an in-tree use and can be removed as API surface.

## Validation

- `CLANG_MODULE_CACHE_PATH=/tmp/rideau-clang-module-cache swift build --disable-sandbox --config-path /tmp/rideau-spm-config --security-path /tmp/rideau-spm-security --manifest-cache local --skip-update --disable-automatic-resolution --sdk /Applications/Xcode-26.4.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk --triple arm64-apple-ios13.0-simulator`