### PR TITLE
Drop minimumActivationDistance from drag gesture configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/FluidGroup/swiftui-scrollview-interoperable-drag-gesture",
-      from: "0.4.0"
+      from: "0.5.0"
     ),
     .package(url: "https://github.com/FluidGroup/swift-rubber-banding", from: "1.0.0"),
   ],

--- a/Rideau/Core/RideauHostingView.swift
+++ b/Rideau/Core/RideauHostingView.swift
@@ -121,8 +121,7 @@ final class RideauHostingView: RideauTouchThroughView {
       ignoresScrollView: false,
       targetEdges: .top,
       sticksToEdges: true,
-      edgeActivationMode: .onlyAtGestureStart,
-      minimumActivationDistance: 15
+      edgeActivationMode: .onlyAtGestureStart
     )
   )
 
@@ -220,8 +219,7 @@ final class RideauHostingView: RideauTouchThroughView {
       ignoresScrollView: ignoresScrollView,
       targetEdges: .top,
       sticksToEdges: true,
-      edgeActivationMode: .onlyAtGestureStart,
-      minimumActivationDistance: 15
+      edgeActivationMode: .onlyAtGestureStart
     )
   }
 

--- a/Rideau/spec.md
+++ b/Rideau/spec.md
@@ -180,7 +180,7 @@ ownership is decided by the submodule using `.onlyAtGestureStart`.
 - scroll-indicator hiding while locked
 
 Minimum version:
-`swiftui-scrollview-interoperable-drag-gesture` `0.4.0`
+`swiftui-scrollview-interoperable-drag-gesture` `0.5.0`
 
 ## 7. Acceptance Tests
 

--- a/Rideau/spec.md
+++ b/Rideau/spec.md
@@ -39,9 +39,10 @@ its valid range. The implementation should follow this spec.
 
 Configuration:
 `edgeActivationMode: .onlyAtGestureStart`, `targetEdges: .top`,
-`sticksToEdges: true`, `minimumActivationDistance: 15`
+`sticksToEdges: true`
 
-- Consume movement smaller than 15 pt and do not forward it to Rideau.
+- Rely on `UIPanGestureRecognizer`'s built-in recognition slop only; do not
+  apply an additional activation distance on top.
 - While `isScrollLockEnabled == true`, fully lock the inner scroll view and send
   all translation to the outer drag.
 - While `isScrollLockEnabled == false`, activate the outer drag only if the
@@ -102,12 +103,13 @@ ownership is decided by the submodule using `.onlyAtGestureStart`.
 - `targetEdges: .top`. No coordination is performed for the bottom edge.
 - Horizontal scrolling should always remain free and must not be locked.
 
-### 3.4 The 15 pt Gate
+### 3.4 Activation Slop
 
-- The 15 pt threshold is owned entirely by the submodule through
-  `minimumActivationDistance: 15`.
-- Rideau should not apply its own additional gate. Once `onChange` fires,
-  Rideau can assume the user has already moved at least 15 pt.
+- Recognition slop is delegated to `UIPanGestureRecognizer`'s built-in
+  threshold. The submodule does not add an additional activation distance,
+  because doing so would let the inner scroll view rubber-band/scroll while
+  the outer drag is still gated.
+- Rideau should not apply its own gate either.
 
 ## 4. Snap Resolution on Gesture End
 
@@ -174,7 +176,6 @@ ownership is decided by the submodule using `.onlyAtGestureStart`.
 - dynamic switching of `isScrollLockEnabled`
 - configurable `targetEdges`
 - `edgeActivationMode: .onlyAtGestureStart`
-- configurable `minimumActivationDistance`
 - deceleration cancellation when locking and unlocking
 - scroll-indicator hiding while locked
 


### PR DESCRIPTION
## Summary
- Bump the `swiftui-scrollview-interoperable-drag-gesture` submodule to drop the activation-distance gate.
- Remove the `minimumActivationDistance: 15` argument from both gesture configurations in `RideauHostingView`.
- Update `spec.md` §3.4 to reflect that activation slop is delegated to `UIPanGestureRecognizer`'s built-in threshold.

## Why
With the old gate, the inner scroll view could rubber-band/scroll at the edge during the 15 pt slop window because the gate returned early before the scroll-view lock ran. `UIPanGestureRecognizer` already has its own recognition threshold, so the custom gate was redundant and degraded edge behavior.

## Dependencies
- Requires FluidGroup/swiftui-scrollview-interoperable-drag-gesture#11 to be merged first.

## Test plan
- [x] `xcodebuild -scheme Rideau build` succeeds against iOS Simulator.
- [x] Submodule test suite green (29/29).
- [ ] Manually exercise the demo app and confirm a sheet drag starting at the scroll view's top edge follows the finger immediately without scroll-view rubber-banding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)